### PR TITLE
Added install RPaths relative to $ORIGIN

### DIFF
--- a/CMake/utils/kwiver-utils-targets.cmake
+++ b/CMake/utils/kwiver-utils-targets.cmake
@@ -105,6 +105,7 @@ function(kwiver_add_executable name)
   set_target_properties(${name}
     PROPERTIES
       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+      INSTALL_RPATH "\$ORIGIN/../lib:\$ORIGIN/"
     )
 
   if(NOT component)
@@ -156,6 +157,8 @@ function(kwiver_add_library     name)
       ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}${library_subdir}"
       LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}${library_subdir}"
       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin${library_subdir}"
+      INSTALL_NAME_DIR "@executable_path/../lib"
+      INSTALL_RPATH "\$ORIGIN/../lib:\$ORIGIN/"
       ${props}
       )
 
@@ -323,6 +326,7 @@ function( kwiver_add_plugin        name )
   set_target_properties( ${name}
     PROPERTIES
       PREFIX           ""
-      SUFFIX           ${CMAKE_SHARED_MODULE_SUFFIX} )
+      SUFFIX           ${CMAKE_SHARED_MODULE_SUFFIX}
+      INSTALL_RPATH "\$ORIGIN/../../lib:\$ORIGIN/" )
 
 endfunction()


### PR DESCRIPTION
This is needed to make relocatable packages for Linux.  The same change was needed in the pre-vital version of MAP-Tk (on which this script was based) in order to build relocatable installers.