### PR TITLE
Dev/os/logger format env vars

### DIFF
--- a/vital/logger/default_logger.cxx
+++ b/vital/logger/default_logger.cxx
@@ -85,7 +85,7 @@ public:
     : kwiver_logger( p, name ),
     m_logLevel( kwiver_logger::LEVEL_TRACE )
   {
-    m_output_time = ( kwiversys::SystemTools::GetEnv( "KWIVER_LOGGER_SUPPRESS_TIME" ) != 0 );
+    m_output_time = ( kwiversys::SystemTools::GetEnv( "KWIVER_LOGGER_SUPPRESS_TIME" ) == 0 );
   }
 
   virtual ~default_logger() VITAL_DEFAULT_DTOR


### PR DESCRIPTION
Introduce environment variable for default logger to suppress timestamps in logging output.

Often it's useful to diff logs when debugging regressions; in these situations, the timestamps just get in the way and have to be awk'd out. This commit checks if the 'KWIVER_LOGGER_SUPPRESS_TIME' environment variable is set, and if so, omits the timestamp from the logger output.

It could be argued that if the user wants this level of control in logging, they should just bite the bullet and install log4cxx, but this approach would be handy if you're in the field and recompiling is not an option.
