### PR TITLE
Support config files in the current working directory

### DIFF
--- a/vital/config/config_parser.cxx
+++ b/vital/config/config_parser.cxx
@@ -168,7 +168,12 @@ public:
     ++m_file_count;
 
     // Get directory part of the input file
-    const config_path_t config_file_dir( kwiversys::SystemTools::GetFilenamePath( file_path ) );
+    config_path_t config_file_dir( kwiversys::SystemTools::GetFilenamePath( file_path ) );
+    // if file_path has no directory prefix then use "." for the current directory
+    if( config_file_dir == "" )
+    {
+      config_file_dir = ".";
+    }
 
     while ( true )
     {


### PR DESCRIPTION
If a config file has no path prefix the directory variable will be
empty.  We need to replace it with "." in this case for correct
operation.