### PR TITLE
Don't include binaries in the export list.

### DIFF
--- a/CMake/utils/kwiver-utils-targets.cmake
+++ b/CMake/utils/kwiver-utils-targets.cmake
@@ -112,7 +112,6 @@ function(kwiver_add_executable name)
     set(component runtime)
   endif()
 
-  _kwiver_export(${name})
   kwiver_install(
     TARGETS     ${name}
     ${exports}


### PR DESCRIPTION
Binaries should only get exported when required by the build process.