### PR TITLE
install enumerate_matrix.h

### DIFF
--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -159,6 +159,7 @@ set( vital_public_headers
 
   util/get_paths.h
   util/timer.h
+  util/enumerate_matrix.h
 )
 
 # ----------------------


### PR DESCRIPTION
This header is used in MAP-Tk, but was not being installed