### PR TITLE
Increment number of characters to include terminator.

### DIFF
--- a/vital/bindings/c/config_block.cxx
+++ b/vital/bindings/c/config_block.cxx
@@ -484,9 +484,7 @@ vital_config_block_file_write( vital_config_block_t*  cb,
     }
     catch ( kwiver::vital::config_file_write_exception const& e )
     {
-      eh->error_code = 1;
-      eh->message = (char*)malloc( sizeof( char ) * (strlen( e.what() )+1) );
-      strcpy( eh->message, e.what() );
+      POPULATE_EH( eh, 1, e.what() );
     }
 
                 );

--- a/vital/bindings/c/config_block.cxx
+++ b/vital/bindings/c/config_block.cxx
@@ -485,7 +485,7 @@ vital_config_block_file_write( vital_config_block_t*  cb,
     catch ( kwiver::vital::config_file_write_exception const& e )
     {
       eh->error_code = 1;
-      eh->message = (char*)malloc( sizeof( char ) * strlen( e.what() ) );
+      eh->message = (char*)malloc( sizeof( char ) * (strlen( e.what() )+1) );
       strcpy( eh->message, e.what() );
     }
 

--- a/vital/bindings/c/helpers/c_utils.cxx
+++ b/vital/bindings/c/helpers/c_utils.cxx
@@ -46,7 +46,7 @@ void make_string_list( std::vector<std::string> const &list,
   strings = (char**)malloc( sizeof(char*) * length );
   for( unsigned int i = 0; i < length; i++ )
   {
-    strings[i] = (char*)malloc(sizeof(char) * list[i].length());
+    strings[i] = (char*)malloc(sizeof(char) * (list[i].length()+1));
     std::strcpy( strings[i], list[i].c_str() );
   }
 }

--- a/vital/bindings/c/helpers/c_utils.h
+++ b/vital/bindings/c/helpers/c_utils.h
@@ -73,7 +73,7 @@ static auto m_logger( kwiver::vital::get_logger( "vital.c_utils" ) );
     {                                                                       \
       PEH_eh_ptr_cast->error_code = ec;                                     \
       free(PEH_eh_ptr_cast->message); /* Does nothing if already null */    \
-      PEH_eh_ptr_cast->message = (char*)malloc(sizeof(char) * strlen(msg)); \
+      PEH_eh_ptr_cast->message = (char*)malloc(sizeof(char) * (strlen(msg)+1)); \
       strcpy(PEH_eh_ptr_cast->message, msg);                                \
     }                                                                       \
   } while(0)

--- a/vital/bindings/c/types/camera.cxx
+++ b/vital/bindings/c/types/camera.cxx
@@ -274,7 +274,7 @@ vital_camera_to_string( vital_camera_t const *cam, vital_error_handle_t *eh )
     ss << *cam_sptr;
     std::string ss_str( ss.str() );
 
-    char *output = (char*)malloc( sizeof(char) * ss_str.length() );
+    char *output = (char*)malloc( sizeof(char) * (ss_str.length()+1) );
     strcpy( output, ss_str.c_str() );
     return output;
   );


### PR DESCRIPTION
For malloc's that are allocating storage for strings, space must
be allocated for the terminating null character.