### PR TITLE
Fix cou_timer.h not found during install.

### DIFF
--- a/vital/CMakeLists.txt
+++ b/vital/CMakeLists.txt
@@ -171,8 +171,6 @@ set( vital_public_headers
   util/demangle.h
   util/any_converter.h
   util/enumerate_matrix.h
-  util/cpu_timer.h
-  util/wall_timer.h
   util/enumerate_matrix.h
 
   plugin_loader/plugin_factory.h


### PR DESCRIPTION
These timer headers were incorrectly included in the public header list.
They are generated at config time and are not in the source
directory so they have to be installed separately.